### PR TITLE
#3 - added filter to retrieve remote jobs from StackOverflow

### DIFF
--- a/lib/jobby_job_job/posting_processor.rb
+++ b/lib/jobby_job_job/posting_processor.rb
@@ -29,7 +29,7 @@ module JobbyJobJob
           parser:"RemoteOk"
         },
         {
-          url:"https://stackoverflow.com/jobs/feed",
+          url:"https://stackoverflow.com/jobs/feed?r=true",
           format:"rss",
           parser:"StackOverflow"
         }


### PR DESCRIPTION
Just added a filter in the URL do retrieve jobs from StackOverflow. With the parameter r=true, we will filter only remote jobs.