### PR TITLE
CSS tweak to display images with proper ratio

### DIFF
--- a/app/assets/stylesheets/root.scss
+++ b/app/assets/stylesheets/root.scss
@@ -36,6 +36,10 @@ a {
   border-color: #ababab !important;
 }
 
+div.card-img-top {
+  height: 3em;
+}
+
 .card-img-top {
   overflow: hidden;
   border-radius: 0.2em;
@@ -43,7 +47,6 @@ a {
   background-position: center;
   background-repeat: no-repeat;
   width: 3em;
-  height: 3em;
   margin: 0;
   margin-right: 0.2em;
   display: inline-block;


### PR DESCRIPTION
(Addresses #25) For images, specify a width but not a height. This
allows the image to retain its correct aspect ratio (albeit
potentially displaying as a very small image) while leaving the
card-img-top div still set to be a square.

A potential caveat here is that if the logo image is very tall,
strange things might happen. However, most corporate logos aren't. :)